### PR TITLE
Fix issue #2 in to-valibot repository

### DIFF
--- a/lib/generator/parser.ts
+++ b/lib/generator/parser.ts
@@ -204,14 +204,18 @@ export class SchemaParser {
         );
 
         // If there are sibling properties, create an object schema and include it
-        if (allOfSchema.properties && Object.keys(allOfSchema.properties).length > 0) {
+        if (
+          allOfSchema.properties &&
+          Object.keys(allOfSchema.properties).length > 0
+        ) {
           const objectSchema: JSONSchemaObject = {
             type: 'object',
             properties: allOfSchema.properties,
             required: allOfRequired,
           };
           if (allOfSchema.additionalProperties !== undefined) {
-            objectSchema.additionalProperties = allOfSchema.additionalProperties;
+            objectSchema.additionalProperties =
+              allOfSchema.additionalProperties;
           }
           const siblingObject = this.parseObjectType(objectSchema, true, meta);
           allOfItems.push(siblingObject);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -70,6 +70,8 @@ interface JSONSchemaObject extends JSONSchemaBase<object> {
 interface JSONSchemaAllOf extends JSONSchemaBase<never> {
   allOf: JSONSchema[];
   required?: string[];
+  properties?: Record<string, JSONSchema>;
+  additionalProperties?: boolean | JSONSchema;
 }
 
 interface JSONSchemaCombined extends JSONSchemaBase<never> {

--- a/spec/generation/fixtures/input/allof-with-properties-schema.json
+++ b/spec/generation/fixtures/input/allof-with-properties-schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "AllOf With Properties",
+  "definitions": {
+    "BaseEntity": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": ["id", "createdAt"]
+    },
+    "EntityDetails": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": ["name"]
+    }
+  },
+  "properties": {
+    "simpleEntity": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseEntity"
+        }
+      ],
+      "properties": {
+        "details": {
+          "$ref": "#/definitions/EntityDetails"
+        }
+      },
+      "required": ["details"]
+    },
+    "extendedEntity": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseEntity"
+        },
+        {
+          "$ref": "#/definitions/EntityDetails"
+        }
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["active", "inactive"]
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["status"]
+    },
+    "strictExtendedEntity": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseEntity"
+        }
+      ],
+      "properties": {
+        "extra": {
+          "type": "string"
+        }
+      },
+      "required": ["extra"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["simpleEntity", "extendedEntity", "strictExtendedEntity"]
+}

--- a/spec/generation/fixtures/output/allof-with-properties-schema.ts
+++ b/spec/generation/fixtures/output/allof-with-properties-schema.ts
@@ -1,0 +1,46 @@
+import { InferOutput, array, intersect, isoDateTime, literal, object, optional, pipe, strictObject, string, union } from "valibot";
+
+
+export const BaseEntitySchema = object({
+  id: string(),
+  createdAt: pipe(string(), isoDateTime()),
+});
+
+export type BaseEntity = InferOutput<typeof BaseEntitySchema>;
+
+
+export const EntityDetailsSchema = object({
+  name: string(),
+  description: optional(string()),
+});
+
+export type EntityDetails = InferOutput<typeof EntityDetailsSchema>;
+
+
+export const AllOfWithPropertiesSchema = object({
+  simpleEntity: intersect([
+    BaseEntitySchema,
+    object({
+      details: EntityDetailsSchema,
+    }),
+  ]),
+  extendedEntity: intersect([
+    BaseEntitySchema,
+    EntityDetailsSchema,
+    object({
+      status: union([
+        literal("active"),
+        literal("inactive"),
+      ]),
+      tags: optional(array(string())),
+    }),
+  ]),
+  strictExtendedEntity: intersect([
+    BaseEntitySchema,
+    strictObject({
+      extra: string(),
+    }),
+  ]),
+});
+
+export type AllOfWithProperties = InferOutput<typeof AllOfWithPropertiesSchema>;

--- a/spec/generation/json-schema.spec.ts
+++ b/spec/generation/json-schema.spec.ts
@@ -219,4 +219,16 @@ describe('should generate valibot schemas from JSON Schemas', () => {
     const parsed = parser.generate();
     expect(parsed.split('\n')).toEqual(prefixItemsNestedOutput.split('\n'));
   });
+
+  it('should parse JSON Schema with allOf and sibling properties', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/allof-with-properties-schema.json'
+    );
+    const allOfWithPropertiesOutput = await getFileContents(
+      'spec/generation/fixtures/output/allof-with-properties-schema.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(allOfWithPropertiesOutput.split('\n'));
+  });
 });


### PR DESCRIPTION
When allOf is combined with sibling properties at the same level in JSON Schema, the properties should be merged into the resulting intersect type. Previously, only the allOf items were processed and sibling properties were ignored, producing an incomplete schema.

This fix:
- Updates JSONSchemaAllOf type to support sibling properties and additionalProperties
- Modifies parser to create an object schema from sibling properties and include it in the allOf result when present
- Adds test case for allOf with sibling properties

Closes #2