### PR TITLE
Fix issue #1 in to-valibot repository

### DIFF
--- a/spec/generation/fixtures/output/no-refs-schema.ts
+++ b/spec/generation/fixtures/output/no-refs-schema.ts
@@ -2,11 +2,17 @@ import { InferOutput, array, boolean, description, email, integer, maxLength, ma
 import { uniqueItems } from "to-valibot/client";
 
 
+/** Schema without any references defining a person */
 export const NoRefsSchema = pipe(object({
+  /** Name of a person */
   name: pipe(string(), minLength(2), maxLength(50), description("Name of a person")),
+  /** Age of a person */
   age: pipe(number(), integer(), minValue(0), maxValue(150), description("Age of a person")),
+  /** Email address of a person */
   email: pipe(string(), email(), description("Email address of a person")),
+  /** Indicates if user is currently active */
   isActive: optional(pipe(boolean(), description("Indicates if user is currently active"))),
+  /** Tags by which user can be found */
   tags: optional(pipe(array(string()), maxLength(5), uniqueItems(), description("Tags by which user can be found"))),
 }), description("Schema without any references defining a person"));
 

--- a/spec/generation/fixtures/output/small-schema.ts
+++ b/spec/generation/fixtures/output/small-schema.ts
@@ -2,10 +2,15 @@ import { InferOutput, array, boolean, description, email, integer, isoDateTime, 
 
 
 export const UserSchema = object({
+  /** Unique identifier for the user */
   id: pipe(string(), uuid(), description("Unique identifier for the user")),
+  /** Full name of the user */
   name: pipe(string(), minLength(2), maxLength(100), description("Full name of the user")),
+  /** User's email address */
   email: pipe(string(), email(), description("User's email address")),
+  /** User's age in years */
   age: optional(pipe(number(), integer(), minValue(0), maxValue(150), description("User's age in years"))),
+  /** Whether the user account is active */
   isActive: optional(pipe(boolean(), description("Whether the user account is active")), true),
   preferences: optional(object({
     theme: optional(union([
@@ -15,8 +20,11 @@ export const UserSchema = object({
     ]), "system"),
     notifications: optional(boolean(), true),
   })),
+  /** User's associated tags */
   tags: optional(pipe(array(string()), maxLength(10), description("User's associated tags"))),
+  /** When the user was created */
   createdAt: optional(pipe(string(), isoDateTime(), description("When the user was created"))),
+  /** Additional user metadata */
   metadata: optional(pipe(object({}), description("Additional user metadata"))),
 });
 
@@ -24,8 +32,11 @@ export type User = InferOutput<typeof UserSchema>;
 
 
 export const ErrorSchema = strictObject({
+  /** Error code */
   code: pipe(string(), description("Error code")),
+  /** Error message */
   message: pipe(string(), description("Error message")),
+  /** Additional error details */
   details: optional(pipe(object({}), description("Additional error details"))),
 });
 

--- a/spec/generation/fixtures/output/uri-format-schema.ts
+++ b/spec/generation/fixtures/output/uri-format-schema.ts
@@ -3,6 +3,7 @@ import { InferOutput, description, object, optional, pipe, string, url } from "v
 
 export const UriFormatTestSchema = object({
   website: pipe(string(), url()),
+  /** User homepage URL */
   homepage: optional(pipe(string(), url(), description("User homepage URL"))),
 });
 


### PR DESCRIPTION
Add JSDoc comments above object properties and schema declarations when they have descriptions. This improves IDE tooltips and type documentation when TypeScript infers the resulting types.

- Add extractDescription() helper to extract descriptions from nodes
- Add generateJSDocComment() helper to format JSDoc comments
- Update object property generation to include JSDoc comments
- Update top-level schema generation to include JSDoc comments
- Update test fixtures to include expected JSDoc output

Fixes #1