### PR TITLE
Add Valibot schema validation support nullable unions

### DIFF
--- a/lib/generator/valibot-generator.ts
+++ b/lib/generator/valibot-generator.ts
@@ -21,8 +21,12 @@ import {
   generateSchemaCode,
 } from './code-generator.ts';
 import { customRules, type CustomRules } from './constants.ts';
-import { SchemaParser } from './parser.ts';
+import { type ParserOptions, SchemaParser } from './parser.ts';
 import { generateSchemaTypeDeclaration } from './type-generator.ts';
+
+export interface ValibotGeneratorOptions {
+  optionalAsNullable: boolean;
+}
 
 const OpenAPISchema = object({
   info: object({
@@ -88,20 +92,33 @@ class ValibotGenerator {
 
   constructor(
     content: string,
-    format: 'openapi-json' | 'openapi-yaml' | 'json'
+    format: 'openapi-json' | 'openapi-yaml' | 'json',
+    options?: ValibotGeneratorOptions
   );
-  constructor(content: object, format: 'openapi-json' | 'json');
+  constructor(
+    content: object,
+    format: 'openapi-json' | 'json',
+    options?: ValibotGeneratorOptions
+  );
   constructor(
     content: string | object,
-    format: 'openapi-json' | 'openapi-yaml' | 'json'
+    format: 'openapi-json' | 'openapi-yaml' | 'json',
+    options?: ValibotGeneratorOptions
   ) {
+    const parserOptions: ParserOptions = {
+      optionalAsNullable: options?.optionalAsNullable ?? false,
+    };
+
     // Initialize parser with shared context
-    this.parser = new SchemaParser({
-      refs: this.refs,
-      schemas: this.schemas,
-      dependsOn: this.dependsOn,
-      currentSchema: null,
-    });
+    this.parser = new SchemaParser(
+      {
+        refs: this.refs,
+        schemas: this.schemas,
+        dependsOn: this.dependsOn,
+        currentSchema: null,
+      },
+      parserOptions
+    );
 
     switch (format) {
       case 'openapi-json': {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,13 @@ import { slugify } from './utils/basic.ts';
 
 interface GeneratorOptions {
   outDir: string;
+  /**
+   * When true, non-required fields will be converted to `union([schema, null()])`
+   * instead of `optional(schema)`.
+   *
+   * @default false
+   */
+  optionalAsNullable?: boolean;
 }
 
 type GenerateOptions =
@@ -24,14 +31,19 @@ const valibotGenerator = (
   options: GeneratorOptions
 ): ValibotGeneratorReturn => {
   const generate = async (opt: GenerateOptions): Promise<void> => {
+    const generatorOptions = {
+      optionalAsNullable: options.optionalAsNullable ?? false,
+    };
+
     if ('schemas' in opt && Array.isArray(opt.schemas)) {
       for (const schema of opt.schemas) {
         const schemaCode =
           typeof schema === 'string'
-            ? new ValibotGenerator(schema, opt.format)
+            ? new ValibotGenerator(schema, opt.format, generatorOptions)
             : new ValibotGenerator(
                 schema,
-                opt.format as 'openapi-json' | 'json'
+                opt.format as 'openapi-json' | 'json',
+                generatorOptions
               );
 
         const code = schemaCode.generate();
@@ -43,7 +55,8 @@ const valibotGenerator = (
       for (const [key, schema] of Object.entries(opt.schemas)) {
         const schemaCode = new ValibotGenerator(
           schema,
-          opt.format as 'openapi-json' | 'json'
+          opt.format as 'openapi-json' | 'json',
+          generatorOptions
         );
 
         const code = schemaCode.generate();
@@ -54,10 +67,11 @@ const valibotGenerator = (
     } else if ('schema' in opt) {
       const schemaCode =
         typeof opt.schema === 'string'
-          ? new ValibotGenerator(opt.schema, opt.format)
+          ? new ValibotGenerator(opt.schema, opt.format, generatorOptions)
           : new ValibotGenerator(
               opt.schema,
-              opt.format as 'openapi-json' | 'json'
+              opt.format as 'openapi-json' | 'json',
+              generatorOptions
             );
 
       const code = schemaCode.generate();

--- a/spec/generation/fixtures/input/default-behavior-schema.json
+++ b/spec/generation/fixtures/input/default-behavior-schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DefaultBehaviorTest",
+  "type": "object",
+  "properties": {
+    "required": {
+      "type": "string"
+    },
+    "optional": {
+      "type": "string"
+    }
+  },
+  "required": ["required"]
+}

--- a/spec/generation/fixtures/input/enum-nullable-schema.json
+++ b/spec/generation/fixtures/input/enum-nullable-schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "EnumNullableTest",
+  "type": "object",
+  "properties": {
+    "requiredStatus": {
+      "type": "string",
+      "enum": ["active", "inactive"]
+    },
+    "optionalStatus": {
+      "type": "string",
+      "enum": ["pending", "complete"]
+    }
+  },
+  "required": ["requiredStatus"]
+}

--- a/spec/generation/fixtures/input/optional-as-nullable-schema.json
+++ b/spec/generation/fixtures/input/optional-as-nullable-schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OptionalAsNullableTest",
+  "type": "object",
+  "properties": {
+    "requiredField": {
+      "type": "string"
+    },
+    "optionalString": {
+      "type": "string"
+    },
+    "optionalNumber": {
+      "type": "number"
+    },
+    "optionalBoolean": {
+      "type": "boolean"
+    },
+    "optionalArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "optionalObject": {
+      "type": "object",
+      "properties": {
+        "nested": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "required": ["requiredField"]
+}

--- a/spec/generation/fixtures/input/ref-nullable-schema.json
+++ b/spec/generation/fixtures/input/ref-nullable-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RefNullableTest",
+  "type": "object",
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        }
+      },
+      "required": ["street"]
+    }
+  },
+  "properties": {
+    "primaryAddress": {
+      "$ref": "#/definitions/Address"
+    },
+    "secondaryAddress": {
+      "$ref": "#/definitions/Address"
+    }
+  },
+  "required": ["primaryAddress"]
+}

--- a/spec/generation/fixtures/output/default-behavior-schema.ts
+++ b/spec/generation/fixtures/output/default-behavior-schema.ts
@@ -1,0 +1,9 @@
+import { InferOutput, object, optional, string } from "valibot";
+
+
+export const DefaultBehaviorTestSchema = object({
+  required: string(),
+  optional: optional(string()),
+});
+
+export type DefaultBehaviorTest = InferOutput<typeof DefaultBehaviorTestSchema>;

--- a/spec/generation/fixtures/output/enum-nullable-schema.ts
+++ b/spec/generation/fixtures/output/enum-nullable-schema.ts
@@ -1,0 +1,18 @@
+import { InferOutput, literal, null, object, union } from "valibot";
+
+
+export const EnumNullableTestSchema = object({
+  requiredStatus: union([
+    literal("active"),
+    literal("inactive"),
+  ]),
+  optionalStatus: union([
+    union([
+      literal("pending"),
+      literal("complete"),
+    ]),
+    null(),
+  ]),
+});
+
+export type EnumNullableTest = InferOutput<typeof EnumNullableTestSchema>;

--- a/spec/generation/fixtures/output/optional-as-nullable-schema.ts
+++ b/spec/generation/fixtures/output/optional-as-nullable-schema.ts
@@ -1,0 +1,33 @@
+import { InferOutput, array, boolean, null, number, object, string, union } from "valibot";
+
+
+export const OptionalAsNullableTestSchema = object({
+  requiredField: string(),
+  optionalString: union([
+    string(),
+    null(),
+  ]),
+  optionalNumber: union([
+    number(),
+    null(),
+  ]),
+  optionalBoolean: union([
+    boolean(),
+    null(),
+  ]),
+  optionalArray: union([
+    array(string()),
+    null(),
+  ]),
+  optionalObject: union([
+    object({
+      nested: union([
+        string(),
+        null(),
+      ]),
+    }),
+    null(),
+  ]),
+});
+
+export type OptionalAsNullableTest = InferOutput<typeof OptionalAsNullableTestSchema>;

--- a/spec/generation/fixtures/output/ref-nullable-schema.ts
+++ b/spec/generation/fixtures/output/ref-nullable-schema.ts
@@ -1,0 +1,19 @@
+import { InferOutput, null, object, string, union } from "valibot";
+
+
+export const AddressSchema = object({
+  street: string(),
+});
+
+export type Address = InferOutput<typeof AddressSchema>;
+
+
+export const RefNullableTestSchema = object({
+  primaryAddress: AddressSchema,
+  secondaryAddress: union([
+    AddressSchema,
+    null(),
+  ]),
+});
+
+export type RefNullableTest = InferOutput<typeof RefNullableTestSchema>;

--- a/spec/generation/optional-as-nullable.spec.ts
+++ b/spec/generation/optional-as-nullable.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { ValibotGenerator } from '../../lib/generator';
+import { getFileContents } from './utils/get-file-contents';
+
+describe('optionalAsNullable option', () => {
+  it('should convert optional fields to union with null when optionalAsNullable is true', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/optional-as-nullable-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/optional-as-nullable-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json', {
+      optionalAsNullable: true,
+    });
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+
+  it('should use optional() by default when optionalAsNullable is not provided', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/default-behavior-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/default-behavior-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+
+  it('should use optional() when optionalAsNullable is explicitly false', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/default-behavior-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/default-behavior-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json', {
+      optionalAsNullable: false,
+    });
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+
+  it('should handle optional references with optionalAsNullable', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/ref-nullable-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/ref-nullable-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json', {
+      optionalAsNullable: true,
+    });
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+
+  it('should handle optional enums with optionalAsNullable', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/enum-nullable-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/enum-nullable-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json', {
+      optionalAsNullable: true,
+    });
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+});


### PR DESCRIPTION
When optionalAsNullable is true, non-required fields are wrapped with union([schema, null()]) instead of optional(schema). This allows users to choose between optional properties (field?: T | undefined) and nullable properties (field: T | null).

Closes #6