### PR TITLE
Fix oneOf properties not wrapped with optional

### DIFF
--- a/lib/generator/parser.ts
+++ b/lib/generator/parser.ts
@@ -241,21 +241,29 @@ export class SchemaParser {
           allOfItems.push(siblingObject);
         }
 
-        return schemaNodeAllOf({
+        let value: AnyNode = schemaNodeAllOf({
           value: allOfItems,
         });
+        if (!required) value = this.wrapAsNonRequired(value);
+        return value;
       } else if ('oneOf' in schema) {
-        return schemaNodeOneOf({
+        let value: AnyNode = schemaNodeOneOf({
           value: schema.oneOf.map((item) => this.parseSchema(item, true, meta)),
         });
+        if (!required) value = this.wrapAsNonRequired(value);
+        return value;
       } else if ('anyOf' in schema) {
-        return schemaNodeAnyOf({
+        let value: AnyNode = schemaNodeAnyOf({
           value: schema.anyOf.map((item) => this.parseSchema(item, true, meta)),
         });
+        if (!required) value = this.wrapAsNonRequired(value);
+        return value;
       } else if ('not' in schema) {
-        return schemaNodeNot({
+        let value: AnyNode = schemaNodeNot({
           value: this.parseSchema(schema.not, true, meta),
         });
+        if (!required) value = this.wrapAsNonRequired(value);
+        return value;
       }
       throw new Error(`Unsupported schema: ${JSON.stringify(schema)}`);
     }

--- a/lib/generator/type-generator.ts
+++ b/lib/generator/type-generator.ts
@@ -92,11 +92,22 @@ export function generateNodeType(node: AnyNode, depth = 1): string {
     }
     case 'const':
       return JSON.stringify(node.value);
-    case 'not':
-    case 'allOf':
+    case 'allOf': {
+      const inner = node.value
+        .map((item) => generateNodeType(item, depth))
+        .join(' & ');
+      return `(${inner})`;
+    }
     case 'anyOf':
-    case 'oneOf':
-      throw new Error(`${node.name} not yet implemented`);
+    case 'oneOf': {
+      const inner = node.value
+        .map((item) => generateNodeType(item, depth))
+        .join(' | ');
+      return `(${inner})`;
+    }
+    case 'not':
+      // TypeScript cannot express "any type except X", so we use unknown
+      return 'unknown';
     case 'optional': {
       throw new Error('Top-level optional is unsupported');
     }

--- a/spec/generation/fixtures/input/optional-logical-operators-schema.json
+++ b/spec/generation/fixtures/input/optional-logical-operators-schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Optional Logical Operators Schema",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "optionalOneOf": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "circle" },
+            "radius": { "type": "number" }
+          },
+          "required": ["type", "radius"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "rectangle" },
+            "width": { "type": "number" },
+            "height": { "type": "number" }
+          },
+          "required": ["type", "width", "height"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "optionalAnyOf": {
+      "anyOf": [
+        { "type": "string" },
+        { "type": "number" }
+      ]
+    },
+    "optionalAllOf": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "age": { "type": "number" }
+          }
+        }
+      ]
+    },
+    "optionalNot": {
+      "not": {
+        "type": "object",
+        "properties": {
+          "forbidden": { "const": true }
+        }
+      }
+    }
+  },
+  "required": ["id"]
+}

--- a/spec/generation/fixtures/output/optional-logical-operators-schema.ts
+++ b/spec/generation/fixtures/output/optional-logical-operators-schema.ts
@@ -1,0 +1,37 @@
+import { InferOutput, intersect, literal, number, object, optional, pipe, strictObject, string, union, uuid } from "valibot";
+import { not } from "to-valibot/client";
+
+
+export const OptionalLogicalOperatorsSchema = object({
+  id: pipe(string(), uuid()),
+  optionalOneOf: optional(union([
+    strictObject({
+      type: literal("circle"),
+      radius: number(),
+    }),
+    strictObject({
+      type: literal("rectangle"),
+      width: number(),
+      height: number(),
+    }),
+  ])),
+  optionalAnyOf: optional(union([
+    string(),
+    number(),
+  ])),
+  optionalAllOf: optional(intersect([
+    object({
+      name: optional(string()),
+    }),
+    object({
+      age: optional(number()),
+    }),
+  ])),
+  optionalNot: optional(not(
+    object({
+      forbidden: literal(true),
+    }),
+  )),
+});
+
+export type OptionalLogicalOperators = InferOutput<typeof OptionalLogicalOperatorsSchema>;

--- a/spec/generation/json-schema.spec.ts
+++ b/spec/generation/json-schema.spec.ts
@@ -231,4 +231,16 @@ describe('should generate valibot schemas from JSON Schemas', () => {
     const parsed = parser.generate();
     expect(parsed.split('\n')).toEqual(allOfWithPropertiesOutput.split('\n'));
   });
+
+  it('should parse JSON Schema with optional logical operators (oneOf, anyOf, allOf, not)', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/optional-logical-operators-schema.json'
+    );
+    const optionalLogicalOperatorsOutput = await getFileContents(
+      'spec/generation/fixtures/output/optional-logical-operators-schema.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(optionalLogicalOperatorsOutput.split('\n'));
+  });
 });


### PR DESCRIPTION
Properties using oneOf, anyOf, allOf, or not that were not in the required array were not being wrapped with optional(). This fix:

- Updates parser.ts to call wrapAsNonRequired() for these schema types when the required parameter is false
- Updates type-generator.ts to properly generate TypeScript types for these schema nodes instead of throwing errors

Adds test case for optional logical operators to verify the fix.