### PR TITLE
Fix definitions support in schema conversion

### DIFF
--- a/lib/generator/valibot-generator.ts
+++ b/lib/generator/valibot-generator.ts
@@ -60,11 +60,20 @@ const JSONSchemaSchema = object({
       )
     )
   ),
-  properties: pipe(
-    any(),
-    check<Record<string, JSONSchemaObject>>(() => true)
+  properties: optional(
+    pipe(
+      any(),
+      check<Record<string, JSONSchemaObject>>(() => true)
+    )
   ),
   required: optional(array(string())),
+  allOf: optional(
+    pipe(
+      any(),
+      check<JSONSchema[]>(() => true)
+    )
+  ),
+  additionalProperties: optional(any()),
 });
 
 type JSONSchemaSchemaType = InferOutput<typeof JSONSchemaSchema>;

--- a/spec/generation/fixtures/input/definitions-with-allof-schema.json
+++ b/spec/generation/fixtures/input/definitions-with-allof-schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Definitions With AllOf",
+  "definitions": {
+    "BaseEntity": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": ["id", "createdAt"]
+    },
+    "ExtendedEntity": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseEntity"
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": ["name"]
+    }
+  },
+  "properties": {
+    "entity": {
+      "$ref": "#/definitions/ExtendedEntity"
+    }
+  },
+  "required": ["entity"]
+}

--- a/spec/generation/fixtures/input/root-allof-only-schema.json
+++ b/spec/generation/fixtures/input/root-allof-only-schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Root AllOf Only",
+  "definitions": {
+    "BaseEntity": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["id"]
+    },
+    "NamedEntity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["name"]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/BaseEntity"
+    },
+    {
+      "$ref": "#/definitions/NamedEntity"
+    }
+  ]
+}

--- a/spec/generation/fixtures/input/root-allof-with-properties-schema.json
+++ b/spec/generation/fixtures/input/root-allof-with-properties-schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Root AllOf With Properties",
+  "definitions": {
+    "BaseEntity": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["id"]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/BaseEntity"
+    }
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": ["name"]
+}

--- a/spec/generation/fixtures/output/definitions-with-allof-schema.ts
+++ b/spec/generation/fixtures/output/definitions-with-allof-schema.ts
@@ -1,0 +1,27 @@
+import { InferOutput, intersect, isoDateTime, object, optional, pipe, string } from "valibot";
+
+
+export const BaseEntitySchema = object({
+  id: string(),
+  createdAt: pipe(string(), isoDateTime()),
+});
+
+export type BaseEntity = InferOutput<typeof BaseEntitySchema>;
+
+
+export const ExtendedEntitySchema = intersect([
+  BaseEntitySchema,
+  object({
+    name: string(),
+    description: optional(string()),
+  }),
+]);
+
+export type ExtendedEntity = InferOutput<typeof ExtendedEntitySchema>;
+
+
+export const DefinitionsWithAllOfSchema = object({
+  entity: ExtendedEntitySchema,
+});
+
+export type DefinitionsWithAllOf = InferOutput<typeof DefinitionsWithAllOfSchema>;

--- a/spec/generation/fixtures/output/root-allof-only-schema.ts
+++ b/spec/generation/fixtures/output/root-allof-only-schema.ts
@@ -1,0 +1,23 @@
+import { InferOutput, intersect, object, string } from "valibot";
+
+
+export const BaseEntitySchema = object({
+  id: string(),
+});
+
+export type BaseEntity = InferOutput<typeof BaseEntitySchema>;
+
+
+export const NamedEntitySchema = object({
+  name: string(),
+});
+
+export type NamedEntity = InferOutput<typeof NamedEntitySchema>;
+
+
+export const RootAllOfOnlySchema = intersect([
+  BaseEntitySchema,
+  NamedEntitySchema,
+]);
+
+export type RootAllOfOnly = InferOutput<typeof RootAllOfOnlySchema>;

--- a/spec/generation/fixtures/output/root-allof-with-properties-schema.ts
+++ b/spec/generation/fixtures/output/root-allof-with-properties-schema.ts
@@ -1,0 +1,18 @@
+import { InferOutput, intersect, object, string } from "valibot";
+
+
+export const BaseEntitySchema = object({
+  id: string(),
+});
+
+export type BaseEntity = InferOutput<typeof BaseEntitySchema>;
+
+
+export const RootAllOfWithPropertiesSchema = intersect([
+  BaseEntitySchema,
+  object({
+    name: string(),
+  }),
+]);
+
+export type RootAllOfWithProperties = InferOutput<typeof RootAllOfWithPropertiesSchema>;

--- a/spec/generation/json-schema.spec.ts
+++ b/spec/generation/json-schema.spec.ts
@@ -243,4 +243,40 @@ describe('should generate valibot schemas from JSON Schemas', () => {
     const parsed = parser.generate();
     expect(parsed.split('\n')).toEqual(optionalLogicalOperatorsOutput.split('\n'));
   });
+
+  it('should parse JSON Schema with root-level allOf and sibling properties', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/root-allof-with-properties-schema.json'
+    );
+    const rootAllOfWithPropertiesOutput = await getFileContents(
+      'spec/generation/fixtures/output/root-allof-with-properties-schema.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(rootAllOfWithPropertiesOutput.split('\n'));
+  });
+
+  it('should parse JSON Schema with root-level allOf only (no sibling properties)', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/root-allof-only-schema.json'
+    );
+    const rootAllOfOnlyOutput = await getFileContents(
+      'spec/generation/fixtures/output/root-allof-only-schema.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(rootAllOfOnlyOutput.split('\n'));
+  });
+
+  it('should parse JSON Schema with definitions containing allOf and sibling properties', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/definitions-with-allof-schema.json'
+    );
+    const definitionsWithAllOfOutput = await getFileContents(
+      'spec/generation/fixtures/output/definitions-with-allof-schema.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(definitionsWithAllOfOutput.split('\n'));
+  });
 });


### PR DESCRIPTION
The fix from PR #3 only handled allOf with sibling properties when they appeared inside properties or definitions, but not when allOf was at the root level of the JSON Schema itself.

This fix:
- Updates ParsedJSONSchema interface to include allOf and additionalProperties
- Updates JSONSchemaSchema validation to accept allOf at root level
- Modifies parseJSONSchema to check for root-level allOf and generate intersect schemas when present
- Adds test cases for root-level allOf with and without sibling properties
- Adds test case for definitions containing allOf with sibling properties