### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2025-01-13
+
+### Added
+
+- **`optionalAsNullable` option** ([#7](https://github.com/muningis/to-valibot/pull/7)) - New option to convert non-required fields to nullable unions (`union([schema, null()])`) instead of using `optional()`. Useful for APIs that represent missing values as `null`.
+
+### Fixed
+
+- **Optional wrapping for logical operators** ([#10](https://github.com/muningis/to-valibot/pull/10)) - Fixed optional wrapping for `oneOf`, `anyOf`, `allOf`, and `not` schemas. Previously, these logical operators were not properly wrapped with `optional()` when they were non-required properties.
+
+- **Support `allOf` at root level** ([#11](https://github.com/muningis/to-valibot/pull/11)) - Fixed parsing of JSON Schema with `allOf` at the root level alongside sibling properties. Previously, root-level `allOf` was ignored and only sibling properties were processed.
+
 ## [1.1.0] - 2025-12-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "to-valibot",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "author": "Rokas Muningis",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump version from 1.1.0 to 1.2.0
- Update CHANGELOG.md with changes since v1.1.0

## Changes in v1.2.0

### Added
- `optionalAsNullable` option (#7)

### Fixed
- Optional wrapping for logical operators (#10)
- Support `allOf` at root level (#11)

🤖 Generated with [Claude Code](https://claude.ai/code)