### PR TITLE
Add OpenAPI schema components definition

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -69,6 +69,7 @@ interface JSONSchemaObject extends JSONSchemaBase<object> {
 
 interface JSONSchemaAllOf extends JSONSchemaBase<never> {
   allOf: JSONSchema[];
+  type?: 'object';
   required?: string[];
   properties?: Record<string, JSONSchema>;
   additionalProperties?: boolean | JSONSchema;

--- a/spec/generation/fixtures/input/openapi-allof-with-type.json
+++ b/spec/generation/fixtures/input/openapi-allof-with-type.json
@@ -1,0 +1,59 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test OpenAPI Schema",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeComponentSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": ["name", "createdAt"]
+      },
+      "ExtendedSchema": {
+        "required": ["id"],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SomeComponentSchema"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ExtendedWithSiblingProps": {
+        "required": ["id", "extra"],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SomeComponentSchema"
+          }
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "extra": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/generation/fixtures/output/openapi-allof-with-type.ts
+++ b/spec/generation/fixtures/output/openapi-allof-with-type.ts
@@ -1,0 +1,30 @@
+import { InferOutput, intersect, isoDateTime, object, pipe, string } from "valibot";
+
+
+export const SomeComponentSchema = object({
+  name: string(),
+  createdAt: pipe(string(), isoDateTime()),
+});
+
+export type SomeComponent = InferOutput<typeof SomeComponentSchema>;
+
+
+export const ExtendedSchema = intersect([
+  SomeComponentSchema,
+  object({
+    id: string(),
+  }),
+]);
+
+export type Extended = InferOutput<typeof ExtendedSchema>;
+
+
+export const ExtendedWithSiblingPropsSchema = intersect([
+  SomeComponentSchema,
+  object({
+    id: string(),
+    extra: string(),
+  }),
+]);
+
+export type ExtendedWithSiblingProps = InferOutput<typeof ExtendedWithSiblingPropsSchema>;

--- a/spec/generation/openapi-json.spec.ts
+++ b/spec/generation/openapi-json.spec.ts
@@ -26,4 +26,16 @@ describe('should generate valibot schemas from OpenAPI json declaration file', (
     const parsed = parser.generate();
     expect(parsed.split('\n')).toEqual(complexSchema.split('\n'));
   });
+
+  it('should handle allOf with type: "object" at same level', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/openapi-allof-with-type.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/openapi-allof-with-type.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'openapi-json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
 });


### PR DESCRIPTION
When a schema has both `type: "object"` and `allOf` at the same level, the parser was checking for `type` first and ignoring the `allOf`. This caused schemas like `{ "type": "object", "allOf": [...], "required": [...] }` to generate an empty `object({})` instead of the proper `intersect`.

The fix moves the `allOf` check before the `type` check in parseSchema, so `allOf` is handled correctly regardless of whether `type` is present.