### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2025-01-13
+
+### Fixed
+
+- **Handle `allOf` with `type: "object"` at same level** ([#13](https://github.com/muningis/to-valibot/pull/13)) - Fixed parsing of OpenAPI schemas where `allOf` appears alongside `type: "object"` at the same level. Previously, the `allOf` was ignored when `type: "object"` was present as a sibling property.
+
 ## [1.2.0] - 2025-01-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "to-valibot",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "author": "Rokas Muningis",
   "repository": {


### PR DESCRIPTION
Update changelog with fix for allOf with type: "object" at same level.