### PR TITLE
Add export position configuration option

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,14 @@ interface GeneratorOptions {
    * @default false
    */
   optionalAsNullable?: boolean;
+  /**
+   * Controls where export declarations are placed in the generated code.
+   * - `'inline'`: Exports are placed inline with declarations (e.g., `export const SchemaName = ...`)
+   * - `'end'`: Exports are collected at the end of the file (e.g., `export { SchemaName }; export type { TypeName }`)
+   *
+   * @default 'inline'
+   */
+  exportPosition?: 'inline' | 'end';
 }
 
 type GenerateOptions =
@@ -33,6 +41,7 @@ const valibotGenerator = (
   const generate = async (opt: GenerateOptions): Promise<void> => {
     const generatorOptions = {
       optionalAsNullable: options.optionalAsNullable ?? false,
+      exportPosition: options.exportPosition ?? 'inline',
     };
 
     if ('schemas' in opt && Array.isArray(opt.schemas)) {

--- a/spec/generation/export-position.spec.ts
+++ b/spec/generation/export-position.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { ValibotGenerator } from '../../lib/generator';
+import { getFileContents } from './utils/get-file-contents';
+
+describe('exportPosition option', () => {
+  it('should use inline exports by default', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/export-position-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/export-position-inline-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+
+  it('should use inline exports when exportPosition is explicitly inline', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/export-position-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/export-position-inline-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json', {
+      exportPosition: 'inline',
+    });
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+
+  it('should collect exports at end when exportPosition is end', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/export-position-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/export-position-end-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json', {
+      exportPosition: 'end',
+    });
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+
+  it('should collect multiple schema exports at end', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/export-position-multi-schema.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/export-position-multi-end-schema.ts'
+    );
+
+    const parser = new ValibotGenerator(schema, 'json', {
+      exportPosition: 'end',
+    });
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
+});

--- a/spec/generation/fixtures/input/export-position-multi-schema.json
+++ b/spec/generation/fixtures/input/export-position-multi-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "User",
+  "type": "object",
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        }
+      },
+      "required": ["street", "city"]
+    }
+  },
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "address": {
+      "$ref": "#/definitions/Address"
+    }
+  },
+  "required": ["id", "address"]
+}

--- a/spec/generation/fixtures/input/export-position-schema.json
+++ b/spec/generation/fixtures/input/export-position-schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "User",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": ["id", "name"]
+}

--- a/spec/generation/fixtures/output/export-position-end-schema.ts
+++ b/spec/generation/fixtures/output/export-position-end-schema.ts
@@ -1,0 +1,12 @@
+import { InferOutput, object, string } from "valibot";
+
+
+const UserSchema = object({
+  id: string(),
+  name: string(),
+});
+
+type User = InferOutput<typeof UserSchema>;
+
+export type { User };
+export { UserSchema };

--- a/spec/generation/fixtures/output/export-position-inline-schema.ts
+++ b/spec/generation/fixtures/output/export-position-inline-schema.ts
@@ -1,0 +1,9 @@
+import { InferOutput, object, string } from "valibot";
+
+
+export const UserSchema = object({
+  id: string(),
+  name: string(),
+});
+
+export type User = InferOutput<typeof UserSchema>;

--- a/spec/generation/fixtures/output/export-position-multi-end-schema.ts
+++ b/spec/generation/fixtures/output/export-position-multi-end-schema.ts
@@ -1,0 +1,20 @@
+import { InferOutput, object, string } from "valibot";
+
+
+const AddressSchema = object({
+  street: string(),
+  city: string(),
+});
+
+type Address = InferOutput<typeof AddressSchema>;
+
+
+const UserSchema = object({
+  id: string(),
+  address: AddressSchema,
+});
+
+type User = InferOutput<typeof UserSchema>;
+
+export type { Address, User };
+export { AddressSchema, UserSchema };


### PR DESCRIPTION
Add new `exportPosition` option to control where export declarations are placed in generated code. Supports 'inline' (default, current behavior) and 'end' (exports collected at end of file).

Example with exportPosition: 'end':
```
const UserSchema = object({});
type User = InferOutput<typeof UserSchema>;

export type { User };
export { UserSchema };
```