### PR TITLE
Refactor to use object merging instead of intersect

### DIFF
--- a/lib/schema-nodes.ts
+++ b/lib/schema-nodes.ts
@@ -359,6 +359,8 @@ const schemaNodeUnion: NodeFactory<SchemaNodeUnion> = (props) => ({
 
 type SchemaNodeAllOf = SchemaNodeBase<'allOf'> & {
   value: AnyNode[];
+  objectType: 'object' | 'strictObject' | 'objectWithRest';
+  withRest?: AnyNode;
 };
 const schemaNodeAllOf: NodeFactory<SchemaNodeAllOf> = (props) => ({
   name: 'allOf',

--- a/spec/generation/fixtures/output/allof-with-properties-schema.ts
+++ b/spec/generation/fixtures/output/allof-with-properties-schema.ts
@@ -1,4 +1,4 @@
-import { InferOutput, array, intersect, isoDateTime, literal, object, optional, pipe, strictObject, string, union } from "valibot";
+import { InferOutput, array, isoDateTime, literal, object, optional, pipe, strictObject, string, union } from "valibot";
 
 
 export const BaseEntitySchema = object({
@@ -18,29 +18,23 @@ export type EntityDetails = InferOutput<typeof EntityDetailsSchema>;
 
 
 export const AllOfWithPropertiesSchema = object({
-  simpleEntity: intersect([
-    BaseEntitySchema,
-    object({
-      details: EntityDetailsSchema,
-    }),
-  ]),
-  extendedEntity: intersect([
-    BaseEntitySchema,
-    EntityDetailsSchema,
-    object({
-      status: union([
-        literal("active"),
-        literal("inactive"),
-      ]),
-      tags: optional(array(string())),
-    }),
-  ]),
-  strictExtendedEntity: intersect([
-    BaseEntitySchema,
-    strictObject({
-      extra: string(),
-    }),
-  ]),
+  simpleEntity: object({
+    ...BaseEntitySchema.entries,
+    details: EntityDetailsSchema,
+  }),
+  extendedEntity: object({
+    ...BaseEntitySchema.entries,
+    ...EntityDetailsSchema.entries,
+    status: union([
+      literal("active"),
+      literal("inactive"),
+    ]),
+    tags: optional(array(string())),
+  }),
+  strictExtendedEntity: strictObject({
+    ...BaseEntitySchema.entries,
+    extra: string(),
+  }),
 });
 
 export type AllOfWithProperties = InferOutput<typeof AllOfWithPropertiesSchema>;

--- a/spec/generation/fixtures/output/definitions-with-allof-schema.ts
+++ b/spec/generation/fixtures/output/definitions-with-allof-schema.ts
@@ -1,4 +1,4 @@
-import { InferOutput, intersect, isoDateTime, object, optional, pipe, string } from "valibot";
+import { InferOutput, isoDateTime, object, optional, pipe, string } from "valibot";
 
 
 export const BaseEntitySchema = object({
@@ -9,13 +9,11 @@ export const BaseEntitySchema = object({
 export type BaseEntity = InferOutput<typeof BaseEntitySchema>;
 
 
-export const ExtendedEntitySchema = intersect([
-  BaseEntitySchema,
-  object({
-    name: string(),
-    description: optional(string()),
-  }),
-]);
+export const ExtendedEntitySchema = object({
+  ...BaseEntitySchema.entries,
+  name: string(),
+  description: optional(string()),
+});
 
 export type ExtendedEntity = InferOutput<typeof ExtendedEntitySchema>;
 

--- a/spec/generation/fixtures/output/enum-nullable-schema.ts
+++ b/spec/generation/fixtures/output/enum-nullable-schema.ts
@@ -1,4 +1,4 @@
-import { InferOutput, literal, null, object, union } from "valibot";
+import { InferOutput, literal, null_, object, union } from "valibot";
 
 
 export const EnumNullableTestSchema = object({
@@ -11,7 +11,7 @@ export const EnumNullableTestSchema = object({
       literal("pending"),
       literal("complete"),
     ]),
-    null(),
+    null_(),
   ]),
 });
 

--- a/spec/generation/fixtures/output/logical-operators-schema.ts
+++ b/spec/generation/fixtures/output/logical-operators-schema.ts
@@ -1,4 +1,4 @@
-import { InferOutput, intersect, isoDateTime, literal, minLength, minValue, number, object, pipe, strictObject, string, union } from "valibot";
+import { InferOutput, isoDateTime, literal, minLength, minValue, number, object, pipe, strictObject, string, union } from "valibot";
 import { not } from "to-valibot/client";
 
 
@@ -10,17 +10,11 @@ export const LogicalOperatorsSchema = object({
       code: string(),
     }),
   ]),
-  allOfExample: intersect([
-    object({
-      id: string(),
-    }),
-    object({
-      name: string(),
-    }),
-    object({
-      age: pipe(number(), minValue(0)),
-    }),
-  ]),
+  allOfExample: object({
+    id: string(),
+    name: string(),
+    age: pipe(number(), minValue(0)),
+  }),
   oneOfExample: union([
     strictObject({
       type: literal("circle"),
@@ -43,16 +37,13 @@ export const LogicalOperatorsSchema = object({
       string(),
       number(),
     ]),
-    metadata: intersect([
+    metadata: pipe(object({
+      created: pipe(string(), isoDateTime()),
+    }), not(
       object({
-        created: pipe(string(), isoDateTime()),
+        deleted: literal(true),
       }),
-      not(
-        object({
-          deleted: literal(true),
-        }),
-      ),
-    ]),
+    )),
   }),
 });
 

--- a/spec/generation/fixtures/output/openapi-allof-with-type.ts
+++ b/spec/generation/fixtures/output/openapi-allof-with-type.ts
@@ -1,4 +1,4 @@
-import { InferOutput, intersect, isoDateTime, object, pipe, string } from "valibot";
+import { InferOutput, isoDateTime, object, pipe, string } from "valibot";
 
 
 export const SomeComponentSchema = object({
@@ -9,22 +9,18 @@ export const SomeComponentSchema = object({
 export type SomeComponent = InferOutput<typeof SomeComponentSchema>;
 
 
-export const ExtendedSchema = intersect([
-  SomeComponentSchema,
-  object({
-    id: string(),
-  }),
-]);
+export const ExtendedSchema = object({
+  ...SomeComponentSchema.entries,
+  id: string(),
+});
 
 export type Extended = InferOutput<typeof ExtendedSchema>;
 
 
-export const ExtendedWithSiblingPropsSchema = intersect([
-  SomeComponentSchema,
-  object({
-    id: string(),
-    extra: string(),
-  }),
-]);
+export const ExtendedWithSiblingPropsSchema = object({
+  ...SomeComponentSchema.entries,
+  id: string(),
+  extra: string(),
+});
 
 export type ExtendedWithSiblingProps = InferOutput<typeof ExtendedWithSiblingPropsSchema>;

--- a/spec/generation/fixtures/output/optional-as-nullable-schema.ts
+++ b/spec/generation/fixtures/output/optional-as-nullable-schema.ts
@@ -1,32 +1,32 @@
-import { InferOutput, array, boolean, null, number, object, string, union } from "valibot";
+import { InferOutput, array, boolean, null_, number, object, string, union } from "valibot";
 
 
 export const OptionalAsNullableTestSchema = object({
   requiredField: string(),
   optionalString: union([
     string(),
-    null(),
+    null_(),
   ]),
   optionalNumber: union([
     number(),
-    null(),
+    null_(),
   ]),
   optionalBoolean: union([
     boolean(),
-    null(),
+    null_(),
   ]),
   optionalArray: union([
     array(string()),
-    null(),
+    null_(),
   ]),
   optionalObject: union([
     object({
       nested: union([
         string(),
-        null(),
+        null_(),
       ]),
     }),
-    null(),
+    null_(),
   ]),
 });
 

--- a/spec/generation/fixtures/output/optional-logical-operators-schema.ts
+++ b/spec/generation/fixtures/output/optional-logical-operators-schema.ts
@@ -1,4 +1,4 @@
-import { InferOutput, intersect, literal, number, object, optional, pipe, strictObject, string, union, uuid } from "valibot";
+import { InferOutput, literal, number, object, optional, pipe, strictObject, string, union, uuid } from "valibot";
 import { not } from "to-valibot/client";
 
 
@@ -19,14 +19,10 @@ export const OptionalLogicalOperatorsSchema = object({
     string(),
     number(),
   ])),
-  optionalAllOf: optional(intersect([
-    object({
-      name: optional(string()),
-    }),
-    object({
-      age: optional(number()),
-    }),
-  ])),
+  optionalAllOf: optional(object({
+    name: optional(string()),
+    age: optional(number()),
+  })),
   optionalNot: optional(not(
     object({
       forbidden: literal(true),

--- a/spec/generation/fixtures/output/ref-nullable-schema.ts
+++ b/spec/generation/fixtures/output/ref-nullable-schema.ts
@@ -1,4 +1,4 @@
-import { InferOutput, null, object, string, union } from "valibot";
+import { InferOutput, null_, object, string, union } from "valibot";
 
 
 export const AddressSchema = object({
@@ -12,7 +12,7 @@ export const RefNullableTestSchema = object({
   primaryAddress: AddressSchema,
   secondaryAddress: union([
     AddressSchema,
-    null(),
+    null_(),
   ]),
 });
 

--- a/spec/generation/fixtures/output/root-allof-only-schema.ts
+++ b/spec/generation/fixtures/output/root-allof-only-schema.ts
@@ -1,4 +1,4 @@
-import { InferOutput, intersect, object, string } from "valibot";
+import { InferOutput, object, string } from "valibot";
 
 
 export const BaseEntitySchema = object({
@@ -15,9 +15,9 @@ export const NamedEntitySchema = object({
 export type NamedEntity = InferOutput<typeof NamedEntitySchema>;
 
 
-export const RootAllOfOnlySchema = intersect([
-  BaseEntitySchema,
-  NamedEntitySchema,
-]);
+export const RootAllOfOnlySchema = object({
+  ...BaseEntitySchema.entries,
+  ...NamedEntitySchema.entries,
+});
 
 export type RootAllOfOnly = InferOutput<typeof RootAllOfOnlySchema>;

--- a/spec/generation/fixtures/output/root-allof-with-properties-schema.ts
+++ b/spec/generation/fixtures/output/root-allof-with-properties-schema.ts
@@ -1,4 +1,4 @@
-import { InferOutput, intersect, object, string } from "valibot";
+import { InferOutput, object, string } from "valibot";
 
 
 export const BaseEntitySchema = object({
@@ -8,11 +8,9 @@ export const BaseEntitySchema = object({
 export type BaseEntity = InferOutput<typeof BaseEntitySchema>;
 
 
-export const RootAllOfWithPropertiesSchema = intersect([
-  BaseEntitySchema,
-  object({
-    name: string(),
-  }),
-]);
+export const RootAllOfWithPropertiesSchema = object({
+  ...BaseEntitySchema.entries,
+  name: string(),
+});
 
 export type RootAllOfWithProperties = InferOutput<typeof RootAllOfWithPropertiesSchema>;


### PR DESCRIPTION
This refactor changes how allOf schemas are generated to use object merging (spreading .entries) instead of Valibot's intersect() function.

Why this change:
- intersect() doesn't work properly with variant() discriminated unions
- Object merging is the recommended approach per Valibot documentation
- This enables proper type inference with discriminated unions

Changes:
- SchemaNodeAllOf now tracks objectType (object/strictObject/objectWithRest)
- Code generator spreads refs as ...RefSchema.entries
- Inline object properties are extracted directly into the merged object
- Non-object constraints (like not()) are wrapped in pipe()
- Fixed null import to use null_ (Valibot's exported name)

Example output change:
Before: intersect([BaseSchema, object({ foo: string() })]) After:  object({ ...BaseSchema.entries, foo: string() })