### PR TITLE
ci: fix Claude action permissions and model config

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,6 +22,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,4 +33,4 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-5-20250929
+          claude_args: '--model claude-sonnet-4-5-20250929'


### PR DESCRIPTION
- Add id-token: write permission for OIDC
- Use claude_args for model instead of invalid model input