### PR TITLE
feat: support JSON Schema array-of-types syntax (type: ["string", "null"])

### DIFF
--- a/lib/generator/parser.ts
+++ b/lib/generator/parser.ts
@@ -289,6 +289,17 @@ export class SchemaParser {
       if (!required) value = this.wrapAsNonRequired(value);
       return value;
     } else if ('type' in schema) {
+      if (Array.isArray(schema.type)) {
+        const branches = schema.type.map((t) =>
+          this.parseSchema({ ...schema, type: t } as JSONSchema, true, meta)
+        );
+        let value: AnyNode =
+          branches.length === 1
+            ? branches[0]!
+            : schemaNodeUnion({ value: branches });
+        if (!required) value = this.wrapAsNonRequired(value, schema.default);
+        return value;
+      }
       switch (schema.type) {
         case 'string':
           if ('enum' in schema) {
@@ -313,7 +324,7 @@ export class SchemaParser {
           return this.parseNullType(schema, required, meta);
         default:
           throw new Error(
-            `Unsupported type: ${(schema as { type: string }).type}`
+            `Unsupported type: ${(schema as { type: unknown }).type}`
           );
       }
     } else {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -85,6 +85,18 @@ interface JSONSchemaRef {
   $ref: string;
 }
 
+interface JSONSchemaMultiType extends JSONSchemaBase<unknown> {
+  type: (
+    | 'string'
+    | 'number'
+    | 'integer'
+    | 'boolean'
+    | 'null'
+    | 'array'
+    | 'object'
+  )[];
+}
+
 type JSONSchema =
   | JSONSchemaString
   | JSONSchemaNumber
@@ -94,6 +106,7 @@ type JSONSchema =
   | JSONSchemaObject
   | JSONSchemaAllOf
   | JSONSchemaCombined
+  | JSONSchemaMultiType
   | JSONSchemaRef;
 
 export type {
@@ -106,5 +119,6 @@ export type {
   JSONSchemaObject,
   JSONSchemaAllOf,
   JSONSchemaCombined,
+  JSONSchemaMultiType,
   JSONSchemaRef,
 };

--- a/spec/generation/fixtures/input/multi-type-schema.json
+++ b/spec/generation/fixtures/input/multi-type-schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MultiTypeTest",
+  "type": "object",
+  "properties": {
+    "nullableString": { "type": ["string", "null"] },
+    "optionalNullableString": { "type": ["string", "null"] },
+    "stringOrNumber": { "type": ["string", "number"] },
+    "integerOrNull": { "type": ["integer", "null"] },
+    "nullOnly": { "type": ["null"] }
+  },
+  "required": ["nullableString", "stringOrNumber", "integerOrNull", "nullOnly"]
+}

--- a/spec/generation/fixtures/input/openapi-31-nullable.json
+++ b/spec/generation/fixtures/input/openapi-31-nullable.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI 3.1 Nullable Example",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string" },
+          "reason": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/spec/generation/fixtures/output/multi-type-schema.ts
+++ b/spec/generation/fixtures/output/multi-type-schema.ts
@@ -1,0 +1,24 @@
+import { InferOutput, integer, null_, number, object, optional, pipe, string, union } from "valibot";
+
+
+export const MultiTypeTestSchema = object({
+  nullableString: union([
+    string(),
+    null_(),
+  ]),
+  optionalNullableString: optional(union([
+    string(),
+    null_(),
+  ])),
+  stringOrNumber: union([
+    string(),
+    number(),
+  ]),
+  integerOrNull: union([
+    pipe(number(), integer()),
+    null_(),
+  ]),
+  nullOnly: null_(),
+});
+
+export type MultiTypeTest = InferOutput<typeof MultiTypeTestSchema>;

--- a/spec/generation/fixtures/output/openapi-31-nullable.ts
+++ b/spec/generation/fixtures/output/openapi-31-nullable.ts
@@ -1,0 +1,12 @@
+import { InferOutput, null_, object, optional, string, union } from "valibot";
+
+
+export const UserSchema = object({
+  id: string(),
+  reason: optional(union([
+    string(),
+    null_(),
+  ])),
+});
+
+export type User = InferOutput<typeof UserSchema>;

--- a/spec/generation/json-schema.spec.ts
+++ b/spec/generation/json-schema.spec.ts
@@ -279,4 +279,16 @@ describe('should generate valibot schemas from JSON Schemas', () => {
     const parsed = parser.generate();
     expect(parsed.split('\n')).toEqual(definitionsWithAllOfOutput.split('\n'));
   });
+
+  it('should parse JSON Schema with array-of-types (type: ["string", "null"])', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/multi-type-schema.json'
+    );
+    const multiTypeOutput = await getFileContents(
+      'spec/generation/fixtures/output/multi-type-schema.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(multiTypeOutput.split('\n'));
+  });
 });

--- a/spec/generation/openapi-json.spec.ts
+++ b/spec/generation/openapi-json.spec.ts
@@ -38,4 +38,16 @@ describe('should generate valibot schemas from OpenAPI json declaration file', (
     const parsed = parser.generate();
     expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
   });
+
+  it('should parse OpenAPI 3.1 schema using type: ["string", "null"] for nullable fields', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/openapi-31-nullable.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/openapi-31-nullable.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'openapi-json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
 });


### PR DESCRIPTION
Lowers array `type` values into a union of each branch's parsed form, so
`type: ["string", "null"]` becomes `union([string(), null_()])`. Single-
element arrays collapse to the lone branch. Unblocks consumption of
OpenAPI 3.1 specs generated by springdoc, FastAPI, NestJS, etc., which
use this syntax (not the removed `nullable: true` keyword) for nullable
fields.

Closes #22