### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.0] - 2026-04-23
+
+### Added
+
+- **Array-of-types syntax (`type: ["string", "null"]`)** ([#22](https://github.com/muningis/to-valibot/issues/22)) - Added support for JSON Schema Draft 6+'s array-of-types syntax, commonly emitted by OpenAPI 3.1 generators (springdoc, FastAPI, NestJS) to express nullable fields in place of the removed `nullable: true` keyword. Array types are lowered to a `union([...])` of each branch, so `type: ["string", "null"]` becomes `union([string(), null_()])`. Single-element arrays collapse to the lone branch. Previously, any occurrence of array-of-types would abort the whole run with `Error: Unsupported type`.
+
 ## [1.5.0] - 2025-01-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "to-valibot",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "author": "Rokas Muningis",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump version to `1.6.0`
- Add `CHANGELOG.md` entry covering the array-of-types syntax support shipped in #23 (closes #22)

## Notes

`1.5.0 -> 1.6.0` (minor) — backward-compatible: previously-rejected JSON Schemas using `type: ["string", "null"]` (the OpenAPI 3.1 nullable form) now parse and emit a `union([X(), null_()])`.

## Test plan

- [x] `pnpm test` (50 passed)
- [x] `pnpm lint`
- [x] `pnpm build`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCrusR4h9TJ4JRiQ8XJCSf)_