### PR TITLE
docs: document release workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,3 +140,16 @@ Unit tests for utilities are colocated: `lib/utils/*.spec.ts`
 3. Add the rule name to the `customRules` array in `lib/generator/valibot-generator.ts`
 4. Use it in the appropriate parser method in `lib/generator/parser.ts` via `action<RuleName>()`
 5. Handle it in `lib/generator/code-generator.ts` (`generateNodeCode()`) to output the function call
+
+## Release Workflow
+
+Whenever a code change ships behavior visible to consumers (new feature, bug fix, parser support for additional schema syntax, etc.), open a follow-up release PR after the change PR is merged:
+
+1. Bump `package.json#version` using semver — new feature or new supported syntax → minor; bug fix only → patch.
+2. Add a `CHANGELOG.md` entry under a new version header (`## [X.Y.Z] - YYYY-MM-DD`) using the existing categories (`Added`, `Changed`, `Fixed`) and link the originating issue or PR.
+3. Commit as two separate commits, in this order:
+   - `chore: bump version to X.Y.Z`
+   - `docs: add changelog entry for vX.Y.Z`
+4. Open a separate PR for the bump (do not bundle it into the feature/fix PR).
+
+Pure-internal changes (refactors with no consumer-visible effect, CI tweaks, dev-only docs) skip this workflow.


### PR DESCRIPTION
## Summary

Adds a **Release Workflow** section to `CLAUDE.md` so every Claude Code session knows to bump `package.json#version` and add a `CHANGELOG.md` entry — in two separate commits, in a separate PR — whenever shipping a consumer-visible change.

## Why

Today this convention only lives in commit history (e.g. PR #21, PR #24). Codifying it in `CLAUDE.md` makes it durable and applies to every contributor using Claude Code in this repo.

## Test plan

- [x] No code change; documentation only
- [x] Captures the exact two-commit pattern already used in PR #21 (`chore:` then `docs:`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCrusR4h9TJ4JRiQ8XJCSf)_