### PR TITLE
fix: parse schemas with properties but no explicit type as objects

### DIFF
--- a/lib/generator/parser.ts
+++ b/lib/generator/parser.ts
@@ -346,6 +346,19 @@ export class SchemaParser {
         });
         if (!required) value = this.wrapAsNonRequired(value);
         return value;
+      } else if (
+        'properties' in schema ||
+        'additionalProperties' in schema ||
+        'patternProperties' in schema ||
+        'propertyNames' in schema ||
+        'minProperties' in schema ||
+        'maxProperties' in schema
+      ) {
+        return this.parseObjectType(
+          { ...(schema as object), type: 'object' } as JSONSchemaObject,
+          required,
+          meta
+        );
       }
       throw new Error(`Unsupported schema: ${JSON.stringify(schema)}`);
     }

--- a/spec/generation/fixtures/input/openapi-discriminator-base.json
+++ b/spec/generation/fixtures/input/openapi-discriminator-base.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Discriminator Schema",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Pet": {
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": ["type"]
+      },
+      "Dog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "bark": {
+                "type": "boolean"
+              }
+            },
+            "required": ["bark"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/generation/fixtures/output/openapi-discriminator-base.ts
+++ b/spec/generation/fixtures/output/openapi-discriminator-base.ts
@@ -1,0 +1,16 @@
+import { InferOutput, boolean, object, string } from "valibot";
+
+
+export const PetSchema = object({
+  type: string(),
+});
+
+export type Pet = InferOutput<typeof PetSchema>;
+
+
+export const DogSchema = object({
+  ...PetSchema.entries,
+  bark: boolean(),
+});
+
+export type Dog = InferOutput<typeof DogSchema>;

--- a/spec/generation/openapi-json.spec.ts
+++ b/spec/generation/openapi-json.spec.ts
@@ -50,4 +50,16 @@ describe('should generate valibot schemas from OpenAPI json declaration file', (
     const parsed = parser.generate();
     expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
   });
+
+  it('should treat schemas with discriminator and properties but no explicit type as objects', async () => {
+    const schema = await getFileContents(
+      'spec/generation/fixtures/input/openapi-discriminator-base.json'
+    );
+    const expectedOutput = await getFileContents(
+      'spec/generation/fixtures/output/openapi-discriminator-base.ts'
+    );
+    const parser = new ValibotGenerator(schema, 'openapi-json');
+    const parsed = parser.generate();
+    expect(parsed.split('\n')).toEqual(expectedOutput.split('\n'));
+  });
 });


### PR DESCRIPTION
## Summary
- OpenAPI base schemas that use `discriminator` typically declare `properties` and `required` without an explicit `type: "object"`. The parser fell through every branch and threw `Unsupported schema: {"discriminator":{"propertyName":"type"},"properties":{"type":{"type":"string"}},"required":["type"]}`.
- The parser now treats any schema carrying object-only fields (`properties`, `additionalProperties`, `patternProperties`, `propertyNames`, `minProperties`, `maxProperties`) as an object when none of the other constructs (`$ref`, `const`, `allOf`, `type`, `oneOf`, `anyOf`, `not`) match.
- Added an OpenAPI fixture covering a discriminator base + `allOf` extension to lock in the behavior.

## Red → Green
1. Added a failing test case in `spec/generation/openapi-json.spec.ts` plus fixture pair (`openapi-discriminator-base.json` / `.ts`). Confirmed it reproduced the original `Unsupported schema` error.
2. Added the object-fallback branch in `lib/generator/parser.ts#parseSchema`. All 51 tests pass; `pnpm lint` is clean.

## Test plan
- [x] `pnpm test --run` (51/51 passing)
- [x] `pnpm lint` (eslint + `tsc --noEmit` clean)
- [ ] Reviewer: confirm the fallback is appropriately scoped — it intentionally ignores OpenAPI's `discriminator` payload (we don't yet emit discriminated unions), but unblocks code generation for these schemas.

> Per `CLAUDE.md`'s release workflow, this is a consumer-visible bug fix and should get a follow-up patch-version bump PR after merge.

https://claude.ai/code/session_01LTJkTHWGB2LVVVdaVMVAPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTJkTHWGB2LVVVdaVMVAPk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parser now intelligently recognizes schema object definitions even without explicit type declarations, improving compatibility with various schema formats.

* **Tests**
  * Added test coverage for discriminator-based schema parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->